### PR TITLE
Add Python support

### DIFF
--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -89,6 +89,7 @@
                 "keyword.operator.expression.in.ts",
                 "keyword.operator.expression.instanceof.ts",
                 "keyword.operator.in.groovy",
+                "keyword.operator.logical.python",
                 "keyword.operator.negation.regexp",
                 "keyword.operator.new.js",
                 "keyword.operator.new.ts",

--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -34,7 +34,9 @@
             "scope": [
                 "constant.character.escape.backslash.regexp",
                 "constant.character.escape.js",
+                "constant.character.escape.python",
                 "constant.character.escape.ts",
+                "constant.character.format.placeholder.other.python",
                 "constant.language.boolean.false.js",
                 "constant.language.boolean.false.ts",
                 "constant.language.boolean.true.js",
@@ -44,6 +46,7 @@
                 "constant.language.json",
                 "constant.language.null.js",
                 "constant.language.null.ts",
+                "constant.language.python",
                 "constant.language.undefined.js",
                 "constant.language.undefined.ts",
                 "constant.other.reference.link.markdown",
@@ -63,11 +66,13 @@
                 "keyword.control.export.js",
                 "keyword.control.export.ts",
                 "keyword.control.flow.js",
+                "keyword.control.flow.python",
                 "keyword.control.flow.ts",
                 "keyword.control.from.js",
                 "keyword.control.from.ts",
                 "keyword.control.groovy",
                 "keyword.control.import.js",
+                "keyword.control.import.python",
                 "keyword.control.import.ts",
                 "keyword.control.java",
                 "keyword.control.loop.js",
@@ -101,10 +106,12 @@
                 "punctuation.definition.bold.markdown",
                 "punctuation.definition.constant.markdown",
                 "punctuation.definition.italic.markdown",
+                "punctuation.separator.arguments.python",
                 "punctuation.separator.comma.js",
                 "punctuation.separator.comma.ts",
                 "punctuation.separator.list.comma.css",
                 "punctuation.separator.parameter.js",
+                "punctuation.separator.parameters.python",
                 "punctuation.separator.parameter.ts",
                 "punctuation.terminator.rule.css",
                 "punctuation.terminator.statement.js",
@@ -120,8 +127,11 @@
                 "storage.modifier.sql",
                 "storage.modifier.static.groovy",
                 "storage.modifier.ts",
+                "storage.type.class.python",
                 "storage.type.def.groovy",
+                "storage.type.format.python",
                 "storage.type.function.js",
+                "storage.type.function.python",
                 "storage.type.function.ts",
                 "storage.type.js",
                 "storage.type.namespace.ts",
@@ -166,11 +176,13 @@
                 "support.variable.property.js",
                 "support.variable.property.process.js",
                 "support.variable.property.process.ts",
+                "variable.language.special.self.python",
                 "variable.other.definition.java",
                 "variable.other.object.property.java",
                 "variable.other.property.java",
                 "variable.other.property.js",
-                "variable.other.property.ts"
+                "variable.other.property.ts",
+                "variable.parameter.function.language.special.self.python"
             ],
             "settings": {
                 "foreground": "#9876aa"
@@ -208,6 +220,7 @@
                 "constant.numeric.css",
                 "constant.numeric.decimal.java",
                 "constant.numeric.decimal.js",
+                "constant.numeric.dec.python",
                 "constant.numeric.decimal.ts",
                 "constant.numeric.groovy",
                 "constant.numeric.hex.js",
@@ -240,6 +253,7 @@
                 "comment.line.double-slash.js",
                 "comment.line.double-slash.ts",
                 "comment.line.number-sign.dockerfile",
+                "comment.line.number-sign.python",
                 "markup.fenced_code.block.markdown",
                 "markup.inline.raw.string.markdown",
                 "markup.raw.block.markdown",
@@ -281,6 +295,8 @@
         },
         {
             "scope": [
+                "entity.name.function.decorator.python",
+                "meta.function.decorator.python support.type.python",
                 "punctuation.definition.annotation.java",
                 "storage.type.annotation.groovy",
                 "storage.type.annotation.java"
@@ -301,6 +317,7 @@
             "scope": [
                 "constant.other.character-class.regexp",
                 "entity.name.function.js",
+                "entity.name.function.python",
                 "entity.name.function.ts",
                 "entity.name.tag.localname.xml",
                 "markup.underline.link.image.markdown",
@@ -324,6 +341,8 @@
                 "constant.other.key.groovy",
                 "markup.quote.markdown",
                 "source.ini",
+                "storage.type.string.python",
+                "string.quoted.docstring.multi.python",
                 "string.quoted.double.css",
                 "string.quoted.double.dockerfile",
                 "string.quoted.double.groovy",
@@ -341,6 +360,7 @@
                 "string.quoted.single.html",
                 "string.quoted.single.java",
                 "string.quoted.single.js",
+                "string.quoted.single.python",
                 "string.quoted.single.sql",
                 "string.quoted.single.ts",
                 "string.quoted.single.xml",
@@ -395,6 +415,46 @@
         },
         {
             "scope": [
+                "support.function.magic.python",
+                "support.variable.magic.python"
+            ],
+            "settings": {
+                "foreground": "#B200B2"
+            }
+        },
+        {
+            "scope": [
+                "support.type.python",
+                "support.function.builtin.python"
+            ],
+            "settings": {
+                "foreground": "#8888C6"
+            }
+        },
+        {
+            "scope": "variable.parameter.function-call.python",
+            "settings": {
+                "foreground": "#AA4926"
+            }
+        },
+        {
+            "scope": [
+                "string.quoted.binary.single.python",
+                "string.quoted.binary.single.python storage.type.string.python"
+            ],
+            "settings": {
+                "foreground": "#A5C261"
+            }
+        },
+        {
+            "scope": "keyword.codetag.notation.python",
+            "settings": {
+                "foreground": "#A8C023",
+                "fontStyle": "italic",
+            }
+        },
+        {
+            "scope": [
                 "constant.character.escape.backslash.regexp",
                 "constant.other.character-class.regexp",
                 "keyword.control.anchor.regexp",
@@ -415,7 +475,13 @@
             "settings": {
                 "fontStyle": "bold"
             }
-        }
+        },
+        {
+            "scope": "string.quoted.docstring.multi.python",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        },
     ],
     "semanticTokenColors": {
         "variable:java": {


### PR DESCRIPTION
Known Python issues:
* print is treated and colored as built-in (back in Python 2, yay!)
* `self` with typing is not treated as `self`, but just as normal positional arg, thus `def (self: Class)` is not properly highlighted
* inspection cannot catch invalid esape sequences, so they are not highlighted as they are in PyCharm
* @param in docstring is not caught
* only TODO and FIXME keywords are caught in uppercase, but not their content
