### PR TITLE
Fix Java enumMember does not match intelliJ

### DIFF
--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -581,6 +581,10 @@
         "variable:java": {
             "foreground": "#9876aa"
         },
+        "enumMember:java": {
+          "fontStyle": "italic",
+          "foreground": "#9876aa"
+        },
         "enumMember:rust": {
             "foreground": "#9876aa"
         },


### PR DESCRIPTION
In IntelliJ enum members are always purple and italic

In the first screenshot enum members are not in italic
In the second screenshot look at line 3, 12 and 15

# screenshots

## IntelliJ

![intelliJ_enum2](https://user-images.githubusercontent.com/64072917/210600373-5081223a-3232-48b3-82f4-b011b38d3168.png)
![intelliJ_enum](https://user-images.githubusercontent.com/64072917/210600367-50ddd353-8dac-4aa0-af2f-40753be310cb.png)

## VSCode before

![VSCode_enum2_before](https://user-images.githubusercontent.com/64072917/210600413-73337b47-c8fb-45a3-9598-c8802a03cfd3.png)
![VSCode_enum_before](https://user-images.githubusercontent.com/64072917/210600439-604ac5a4-8047-407a-960f-bc3942b32aea.png)

## VSCode after

![VSCode_enum2_after](https://user-images.githubusercontent.com/64072917/210600456-867c2f46-8329-4867-93e5-56cf04cc0740.png)
![VSCode_enum_after](https://user-images.githubusercontent.com/64072917/210600473-fc4a5bd3-fcee-4be1-969f-625549d5e1f3.png)

