### PR TITLE
Set static properties and methods in italic

### DIFF
--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -581,6 +581,15 @@
         "property:java": {
             "foreground": "#9876aa"
         },
+        "property.static:java": {
+            "fontStyle": "italic"
+        },
+        "method.static:java": {
+            "fontStyle": "italic"
+        },
+        "method.static.declaration:java": {
+            "fontStyle": ""
+        },
         "enumMember:java": {
           "fontStyle": "italic",
           "foreground": "#9876aa"


### PR DESCRIPTION
In IntelliJ, static properties and methods references are in italic but not static methods declarations.

_Note: I have the redhat.javaredhat.java extention enabled_

# Screenshots

Look at line 5,8,12,15,16

## IntelliJ
![intelliJ_static](https://user-images.githubusercontent.com/64072917/211212233-54bf1f96-7a1f-4e3e-b798-be71357bb68e.png)

## VSCode before
![VSCode_static_before](https://user-images.githubusercontent.com/64072917/211212238-a21fb3aa-6899-4474-a36c-0ac8809a244c.png)

## VSCode after
![VSCode_static_after](https://user-images.githubusercontent.com/64072917/211212360-a2a27a15-27c7-4581-8287-48b7cb8ae2ed.png)

