### PR TITLE
Closes #12 Add support for SCSS

### DIFF
--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -533,6 +533,7 @@
                 "punctuation.definition.interpolation.end.bracket.curly.scss",
                 "entity.other.attribute-name.pseudo-element.css", // Added for scss but also applies to css.
                 "entity.other.attribute-name.pseudo-class.css", // Added for scss but also applies to css.
+                "entity.other.attribute-name.parent-selector-suffix.css punctuation.definition.entity.css",
                 "entity.name.function.scss",
                 "punctuation.definition.character-class.regexp",
                 "punctuation.definition.group.regexp",

--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -57,6 +57,7 @@
                 "constant.language.undefined.tsx",
                 "constant.other.reference.link.markdown",
                 "entity.name.tag.wildcard.css",
+                "entity.name.tag.wildcard.scss",
                 "entity.name.tag.yaml",
                 "entity.name.type.numeric.rust",
                 "entity.other.attribute-name.table.toml",
@@ -65,9 +66,31 @@
                 "keyword.control.as.tsx",
                 "keyword.control.assert.groovy",
                 "keyword.control.at-rule.font-face.css",
+                "keyword.control.at-rule.fontface.scss",
                 "keyword.control.at-rule.import.css",
+                "keyword.control.at-rule.import.scss",
                 "keyword.control.at-rule.keyframes.css",
+                "keyword.control.at-rule.keyframes.scss",
                 "keyword.control.at-rule.media.css",
+                "keyword.control.at-rule.media.scss",
+                "keyword.control.at-rule.use.scss",
+                "keyword.control.at-rule.forward.scss",
+                "keyword.control.at-rule.mixin.scss",
+                "keyword.control.at-rule.include.scss",
+                "keyword.control.at-rule.function.scss",
+                "keyword.control.at-rule.at-root.scss",
+                "keyword.control.at-rule.extend.scss",
+                "keyword.control.return.scss",
+                "keyword.control.content.scss",
+                "keyword.control.warn.scss",
+                "keyword.control.at-rule.supports.scss",
+                "keyword.control.for.scss",
+                "meta.at-rule.for.scss keyword.control.operator",
+                "keyword.control.each.scss",
+                "meta.at-rule.each.scss keyword.control.operator",
+                "keyword.control.while.scss",
+                "keyword.control.if.scss",
+                "keyword.control.else.scss",
                 "keyword.control.catch.java",
                 "keyword.control.conditional.js",
                 "keyword.control.conditional.ts",
@@ -121,6 +144,7 @@
                 "keyword.other.import.groovy",
                 "keyword.other.import.java",
                 "keyword.other.important.css",
+                "keyword.other.important.scss",
                 "keyword.other.package.groovy",
                 "keyword.other.package.java",
                 "keyword.other.rust",
@@ -144,6 +168,7 @@
                 "punctuation.separator.parameter.ts",
                 "punctuation.separator.parameter.tsx",
                 "punctuation.terminator.rule.css",
+                "punctuation.terminator.rule.scss",
                 "punctuation.terminator.statement.js",
                 "punctuation.terminator.statement.ts",
                 "punctuation.terminator.statement.tsx",
@@ -233,7 +258,8 @@
                 "variable.other.property.js",
                 "variable.other.property.ts",
                 "variable.other.property.tsx",
-                "variable.parameter.function.language.special.self.python"
+                "variable.parameter.function.language.special.self.python",
+                "variable.scss"
             ],
             "settings": {
                 "foreground": "#9876aa"
@@ -251,17 +277,23 @@
             "scope": [
                 "keyword.operator.combinator.css",
                 "keyword.operator.pattern.css",
+                "keyword.operator.pattern.scss",
                 "meta.method.body.java variable.other.definition.java",
                 "meta.template.expression.js",
                 "meta.template.expression.ts",
                 "meta.template.expression.tsx",
                 "punctuation.definition.entity.begin.bracket.square.css",
-                "punctuation.definition.entity.css",
+                "punctuation.definition.attribute-selector.begin.bracket.square.scss",
+                "punctuation.definition.entity.css", // Used for css and scss.
                 "punctuation.definition.entity.end.bracket.square.css",
+                "punctuation.definition.attribute-selector.end.bracket.square.scss",
                 "punctuation.section.function.begin.bracket.round.css",
+                "punctuation.definition.pseudo-class.begin.bracket.round.css",
                 "punctuation.section.function.end.bracket.round.css",
+                "punctuation.definition.pseudo-class.end.bracket.round.css",
                 "punctuation.separator.key-value.js",
-                "source.groovy.embedded.source"
+                "source.groovy.embedded.source",
+                "keyword.operator.css"
             ],
             "settings": {
                 "foreground": "#a9b7c6"
@@ -269,7 +301,7 @@
         },
         {
             "scope": [
-                "constant.numeric.css",
+                "constant.numeric.css", // Used for css and scss.
                 "constant.numeric.decimal.java",
                 "constant.numeric.decimal.js",
                 "constant.numeric.dec.python",
@@ -284,7 +316,7 @@
                 "constant.numeric.integer.toml",
                 "constant.numeric.json",
                 "constant.numeric.sql",
-                "constant.other.color.rgb-value.hex.css",
+                "constant.other.color.rgb-value.hex.css", // Used for css and scss.
                 "keyword.operator.quantifier.regexp",
                 "string.regexp.js punctuation.definition.string.begin.js",
                 "string.regexp.ts punctuation.definition.string.begin.ts",
@@ -300,6 +332,7 @@
         {
             "scope": [
                 "comment.block.css",
+                "comment.block.scss",
                 "comment.block.groovy",
                 "comment.block.html",
                 "comment.block.java",
@@ -309,6 +342,7 @@
                 "comment.block.ts",
                 "comment.block.tsx",
                 "comment.block.xml",
+                "comment.line.scss",
                 "comment.line.double-slash.groovy",
                 "comment.line.double-slash.java",
                 "comment.line.double-slash.js",
@@ -416,6 +450,7 @@
                 "storage.type.string.python",
                 "string.quoted.docstring.multi.python",
                 "string.quoted.double.css",
+                "string.quoted.double.scss",
                 "string.quoted.double.dockerfile",
                 "string.quoted.double.groovy",
                 "string.quoted.double.html",
@@ -431,6 +466,7 @@
                 "string.quoted.single.basic.line.toml",
                 "string.quoted.single.char.rust",
                 "string.quoted.single.css",
+                "string.quoted.single.scss",
                 "string.quoted.single.dockerfile",
                 "string.quoted.single.groovy",
                 "string.quoted.single.html",
@@ -466,7 +502,8 @@
                 "punctuation.definition.link.markdown",
                 "string.other.link.description.markdown",
                 "string.other.link.title.markdown",
-                "variable.parameter.url.css"
+                "variable.parameter.url.css",
+                "variable.parameter.url.scss"
             ],
             "settings": {
                 "foreground": "#287bde"
@@ -476,20 +513,34 @@
             "scope": [
                 "entity.name.tag.html",
                 "entity.name.tag.tsx",
-                "entity.other.attribute-name.id.css punctuation.definition.entity.css",
+                "entity.other.attribute-name.id.css punctuation.definition.entity.css", // Used for css and scss.
                 "entity.other.keyframe-offset.css",
                 "entity.other.keyframe-offset.percentage.css",
+                "meta.at-rule.keyframes.scss entity.other.attribute-name.scss",
                 "keyword.operator.logical.and.media.css",
+                "keyword.operator.logical.scss",
                 "keyword.operator.logical.only.media.css",
+                "keyword.control.operator.css.scss",
                 "meta.property-value.css",
+                "meta.property-value.scss",
                 "meta.selector.css",
+                "entity.other.attribute-name.class.css", // Added for scss but also applies to css.
+                "entity.name.tag.css", // Added for scss but also applies to css.
+                "entity.name.tag.reference.scss",
+                "entity.other.attribute-name.id.css", // Added for scss but also applies to css.
+                "support.function.misc.scss",
+                "punctuation.definition.interpolation.begin.bracket.curly.scss",
+                "punctuation.definition.interpolation.end.bracket.curly.scss",
+                "entity.other.attribute-name.pseudo-element.css", // Added for scss but also applies to css.
+                "entity.other.attribute-name.pseudo-class.css", // Added for scss but also applies to css.
+                "entity.name.function.scss",
                 "punctuation.definition.character-class.regexp",
                 "punctuation.definition.group.regexp",
                 "punctuation.definition.tag.begin.html",
                 "punctuation.definition.tag.begin.tsx",
                 "punctuation.definition.tag.end.html",
                 "punctuation.definition.tag.end.tsx",
-                "support.constant.media.css"
+                "support.constant.media.css" // Used for css and scss.
             ],
             "settings": {
                 "foreground": "#e8bf6a"
@@ -543,6 +594,7 @@
                 "keyword.operator.negation.regexp",
                 "keyword.operator.or.regexp",
                 "keyword.other.important.css",
+                "keyword.other.important.scss",
                 "support.class.builtin.js",
                 "support.class.builtin.ts",
                 "support.class.builtin.tsx",

--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -284,7 +284,7 @@
                 "meta.template.expression.tsx",
                 "punctuation.definition.entity.begin.bracket.square.css",
                 "punctuation.definition.attribute-selector.begin.bracket.square.scss",
-                "punctuation.definition.entity.css", // Used for css and scss.
+                "punctuation.definition.entity.css",
                 "punctuation.definition.entity.end.bracket.square.css",
                 "punctuation.definition.attribute-selector.end.bracket.square.scss",
                 "punctuation.section.function.begin.bracket.round.css",
@@ -301,7 +301,7 @@
         },
         {
             "scope": [
-                "constant.numeric.css", // Used for css and scss.
+                "constant.numeric.css",
                 "constant.numeric.decimal.java",
                 "constant.numeric.decimal.js",
                 "constant.numeric.dec.python",
@@ -316,7 +316,7 @@
                 "constant.numeric.integer.toml",
                 "constant.numeric.json",
                 "constant.numeric.sql",
-                "constant.other.color.rgb-value.hex.css", // Used for css and scss.
+                "constant.other.color.rgb-value.hex.css",
                 "keyword.operator.quantifier.regexp",
                 "string.regexp.js punctuation.definition.string.begin.js",
                 "string.regexp.ts punctuation.definition.string.begin.ts",
@@ -513,7 +513,7 @@
             "scope": [
                 "entity.name.tag.html",
                 "entity.name.tag.tsx",
-                "entity.other.attribute-name.id.css punctuation.definition.entity.css", // Used for css and scss.
+                "entity.other.attribute-name.id.css punctuation.definition.entity.css",
                 "entity.other.keyframe-offset.css",
                 "entity.other.keyframe-offset.percentage.css",
                 "meta.at-rule.keyframes.scss entity.other.attribute-name.scss",
@@ -524,15 +524,15 @@
                 "meta.property-value.css",
                 "meta.property-value.scss",
                 "meta.selector.css",
-                "entity.other.attribute-name.class.css", // Added for scss but also applies to css.
-                "entity.name.tag.css", // Added for scss but also applies to css.
+                "entity.other.attribute-name.class.css",
+                "entity.name.tag.css",
                 "entity.name.tag.reference.scss",
-                "entity.other.attribute-name.id.css", // Added for scss but also applies to css.
+                "entity.other.attribute-name.id.css",
                 "support.function.misc.scss",
                 "punctuation.definition.interpolation.begin.bracket.curly.scss",
                 "punctuation.definition.interpolation.end.bracket.curly.scss",
-                "entity.other.attribute-name.pseudo-element.css", // Added for scss but also applies to css.
-                "entity.other.attribute-name.pseudo-class.css", // Added for scss but also applies to css.
+                "entity.other.attribute-name.pseudo-element.css",
+                "entity.other.attribute-name.pseudo-class.css",
                 "entity.other.attribute-name.parent-selector-suffix.css punctuation.definition.entity.css",
                 "entity.name.function.scss",
                 "punctuation.definition.character-class.regexp",
@@ -541,7 +541,7 @@
                 "punctuation.definition.tag.begin.tsx",
                 "punctuation.definition.tag.end.html",
                 "punctuation.definition.tag.end.tsx",
-                "support.constant.media.css" // Used for css and scss.
+                "support.constant.media.css"
             ],
             "settings": {
                 "foreground": "#e8bf6a"


### PR DESCRIPTION
This PR Closes #12 Add support for SCSS.

There are a few problems I didn't manage to solve, they are listed bellow:
- When using parent selector plus a suffix that begins with "--", the suffix is colored as a variable instead of a selector:

    ![imagen](https://user-images.githubusercontent.com/64830228/222900748-171eefc7-490a-4d53-be47-63341eb4c85f.png)

- Commas do not have a specific scope assigned so they can't be colored:

    ![imagen](https://user-images.githubusercontent.com/64830228/222900990-d319bdd8-ae32-4ed2-9cbb-c8f4123beeec.png)

- When using a list as a property in a keyframe only the last item is colored:

    ![imagen](https://user-images.githubusercontent.com/64830228/222906727-a0eb36e5-9b0c-41a2-851e-80b5cb5e4964.png)

- Methods are not colored when they are used inside a keyword.control.warn.scss:

    ![imagen](https://user-images.githubusercontent.com/64830228/222906888-5a09813d-8b1e-44dd-87a5-4f9d9ca38b42.png)
