### PR TITLE
Closes #15 Undefined color token for js "class" keyword.

### DIFF
--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -185,6 +185,7 @@
         "storage.modifier.static.groovy",
         "storage.modifier.ts",
         "storage.modifier.tsx",
+        "storage.type.class.js",
         "storage.type.class.python",
         "storage.type.class.tsx",
         "storage.type.def.groovy",


### PR DESCRIPTION
# Closes #15 Undefined color token for js "class" keyword.

Added the scope `storage.type.class.js` to modify the color of the "class" keyword in JavaScript as described in issue #15.