### PR TITLE
Fixes #18 No color assigned to js storage modifiers

### DIFF
--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -183,6 +183,7 @@
         "storage.modifier.java",
         "storage.modifier.sql",
         "storage.modifier.static.groovy",
+		"storage.modifier.js",
         "storage.modifier.ts",
         "storage.modifier.tsx",
         "storage.type.class.js",

--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -183,7 +183,7 @@
         "storage.modifier.java",
         "storage.modifier.sql",
         "storage.modifier.static.groovy",
-		"storage.modifier.js",
+        "storage.modifier.js",
         "storage.modifier.ts",
         "storage.modifier.tsx",
         "storage.type.class.js",


### PR DESCRIPTION
Fixes #18 No color assigned to js storage modifiers by adding the scope `"storage.modifier.js"`:

**Before:**

![2023-08-06_11h34_21](https://github.com/rafaelrenanpacheco/darcula-theme/assets/64830228/2acc4b72-c82c-4433-8b26-1ad7e0610a18)

**After:**

![2023-08-06_11h34_02](https://github.com/rafaelrenanpacheco/darcula-theme/assets/64830228/0a11df70-1e77-467e-b7d2-fa1c647d138c)
