### PR TITLE
Closes #21 Add Makefile support

### DIFF
--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -96,7 +96,7 @@
         "keyword.control.directive.include.c",
         "keyword.control.each.scss",
         "keyword.control.else.scss",
-		"keyword.control.else.makefile",
+        "keyword.control.else.makefile",
         "keyword.control.export.js",
         "keyword.control.export.ts",
         "keyword.control.export.tsx",
@@ -131,11 +131,11 @@
         "keyword.control.trycatch.tsx",
         "keyword.control.warn.scss",
         "keyword.control.while.scss",
-		"keyword.control.include.makefile",
-		"keyword.control.ifeq.makefile",
-		"keyword.control.endif.makefile",
-		"keyword.control.override.makefile",
-		"keyword.control.define.makefile",
+        "keyword.control.include.makefile",
+        "keyword.control.ifeq.makefile",
+        "keyword.control.endif.makefile",
+        "keyword.control.override.makefile",
+        "keyword.control.define.makefile",
         "keyword.key.toml",
         "keyword.operator.expression.in.js",
         "keyword.operator.expression.in.ts",
@@ -168,7 +168,7 @@
         "punctuation.definition.bold.markdown",
         "punctuation.definition.constant.markdown",
         "punctuation.definition.italic.markdown",
-		"punctuation.definition.variable.makefile",
+        "punctuation.definition.variable.makefile",
         "punctuation.section.embedded.begin.tsx",
         "punctuation.section.embedded.end.tsx",
         "punctuation.semi.rust",
@@ -284,7 +284,7 @@
         "variable.other.property.js",
         "variable.other.property.ts",
         "variable.other.property.tsx",
-		"variable.other.makefile",
+        "variable.other.makefile",
         "variable.parameter.function.language.special.self.python",
         "variable.scss"
       ],
@@ -321,8 +321,8 @@
         "punctuation.section.function.end.bracket.round.css",
         "punctuation.separator.key-value.js",
         "source.groovy.embedded.source",
-		"meta.scope.prerequisites.makefile",
-		"punctuation.separator.key-value.makefile"
+        "meta.scope.prerequisites.makefile",
+        "punctuation.separator.key-value.makefile"
       ],
       "settings": {
         "foreground": "#a9b7c6"
@@ -385,7 +385,7 @@
         "comment.line.number-sign.python",
         "comment.line.number-sign.toml",
         "comment.line.scss",
-		"comment.line.number-sign.makefile",
+        "comment.line.number-sign.makefile",
         "markup.fenced_code.block.markdown",
         "markup.inline.raw.string.markdown",
         "markup.raw.block.markdown",
@@ -446,7 +446,7 @@
     {
       "scope": [
         "meta.declaration.annotation.java constant.other.key.java",
-		"variable.language.makefile"
+        "variable.language.makefile"
       ],
       "settings": {
         "foreground": "#d0d0ff"
@@ -474,7 +474,7 @@
         "support.function.ts",
         "support.function.tsx",
         "variable.other.readwrite.alias.js",
-		"meta.scope.target.makefile"
+        "meta.scope.target.makefile"
       ],
       "settings": {
         "foreground": "#ffc66d"

--- a/themes/darcula.color-theme.json
+++ b/themes/darcula.color-theme.json
@@ -96,6 +96,7 @@
         "keyword.control.directive.include.c",
         "keyword.control.each.scss",
         "keyword.control.else.scss",
+		"keyword.control.else.makefile",
         "keyword.control.export.js",
         "keyword.control.export.ts",
         "keyword.control.export.tsx",
@@ -130,6 +131,11 @@
         "keyword.control.trycatch.tsx",
         "keyword.control.warn.scss",
         "keyword.control.while.scss",
+		"keyword.control.include.makefile",
+		"keyword.control.ifeq.makefile",
+		"keyword.control.endif.makefile",
+		"keyword.control.override.makefile",
+		"keyword.control.define.makefile",
         "keyword.key.toml",
         "keyword.operator.expression.in.js",
         "keyword.operator.expression.in.ts",
@@ -162,6 +168,7 @@
         "punctuation.definition.bold.markdown",
         "punctuation.definition.constant.markdown",
         "punctuation.definition.italic.markdown",
+		"punctuation.definition.variable.makefile",
         "punctuation.section.embedded.begin.tsx",
         "punctuation.section.embedded.end.tsx",
         "punctuation.semi.rust",
@@ -277,6 +284,7 @@
         "variable.other.property.js",
         "variable.other.property.ts",
         "variable.other.property.tsx",
+		"variable.other.makefile",
         "variable.parameter.function.language.special.self.python",
         "variable.scss"
       ],
@@ -312,7 +320,9 @@
         "punctuation.section.function.begin.bracket.round.css",
         "punctuation.section.function.end.bracket.round.css",
         "punctuation.separator.key-value.js",
-        "source.groovy.embedded.source"
+        "source.groovy.embedded.source",
+		"meta.scope.prerequisites.makefile",
+		"punctuation.separator.key-value.makefile"
       ],
       "settings": {
         "foreground": "#a9b7c6"
@@ -375,6 +385,7 @@
         "comment.line.number-sign.python",
         "comment.line.number-sign.toml",
         "comment.line.scss",
+		"comment.line.number-sign.makefile",
         "markup.fenced_code.block.markdown",
         "markup.inline.raw.string.markdown",
         "markup.raw.block.markdown",
@@ -434,7 +445,8 @@
     },
     {
       "scope": [
-        "meta.declaration.annotation.java constant.other.key.java"
+        "meta.declaration.annotation.java constant.other.key.java",
+		"variable.language.makefile"
       ],
       "settings": {
         "foreground": "#d0d0ff"
@@ -461,7 +473,8 @@
         "support.function.js",
         "support.function.ts",
         "support.function.tsx",
-        "variable.other.readwrite.alias.js"
+        "variable.other.readwrite.alias.js",
+		"meta.scope.target.makefile"
       ],
       "settings": {
         "foreground": "#ffc66d"


### PR DESCRIPTION
# Closes #21 Add Makefile support

I couldn't find many references to the InterlliJ theme for Makefile so I used the VS Code dark theme as a reference to apply the existing color tokens. Here's a comparison between the two, any suggestions are welcome:

Note that the code is just a bunch of random examples don't try to make sense out of it.

**VS Code dark theme:**

![2023-12-27_19-23-37](https://github.com/rafaelrenanpacheco/darcula-theme/assets/64830228/4ab526fc-4e29-4098-b239-3a9aefb66a39)

**New theme:**

![2023-12-27_19-23-11](https://github.com/rafaelrenanpacheco/darcula-theme/assets/64830228/ee4e7119-59ec-4a63-9df4-853de8043ae2)

**VS Code dark theme:**

![2023-12-27_19-27-16](https://github.com/rafaelrenanpacheco/darcula-theme/assets/64830228/a261efc1-137d-4b58-b722-2f0a7110f8ef)

**New theme:**

![2023-12-27_19-26-52](https://github.com/rafaelrenanpacheco/darcula-theme/assets/64830228/ad270c32-f79e-4e09-8b2d-da0b56440d40)


